### PR TITLE
init value cannot be used in code

### DIFF
--- a/gui-easy/gui/easy/scribblings/custom-views.scrbl
+++ b/gui-easy/gui/easy/scribblings/custom-views.scrbl
@@ -47,7 +47,7 @@ implementation of @racketid[canvas-list-view%]:
 @racketblock[
   (define canvas-list-view%
     (class* object% (view<%>)
-      (init |@entries| draw action)
+      (init-field |@entries| draw action)
       (super-new)
 
       (define/public (dependencies)


### PR DESCRIPTION
current code will get error:
```
class: cannot use non-field init variable in a method in: @entries
```