### PR TITLE
fixes instantiate: unused initialization arguments [id id]

### DIFF
--- a/gui-easy-lib/gui/easy/private/renderer.rkt
+++ b/gui-easy-lib/gui/easy/private/renderer.rkt
@@ -78,7 +78,7 @@
 
 (define (render-popup-menu r tree x y)
   (define id (next-id!))
-  (define menu-r (new renderer% [id id] [tree tree]))
+  (define menu-r (new renderer% [tree tree]))
   (define menu (send menu-r render #f))
   (define window (send r get-root))
   (log-gui-easy-debug "rendered popup menu ~a" id)


### PR DESCRIPTION
testing with this module:
```
#lang racket/base

(require racket/gui/easy)

(provide show)

(define (show)
  ;; popup menu
  (define m (popup-menu (menu "&Product"
                              (menu-item "Item&1..." (λ () (void)))
                              (menu-item "Item&2..." (λ () (void)))
                              (menu-item-separator)
                              (menu-item "&Quit"))
                        (menu "Menu&2"
                              (menu-item "Item&1..." (λ () (void))))))
  (define main-window (window
                       #:title "Popup test"
                       #:size '(1024 768)
                       (menu-bar
                        (menu "&Product"
                              (menu-item "Item&1..." (λ () (void)))
                              (menu-item "Item&2..." (λ () (void)))
                              (menu-item-separator)
                              (menu-item "&Quit"))
                        (menu "Menu&2"
                              (menu-item "Item&1..." (λ () (void))))
                        (menu "&Account"
                              (menu-item "&Accounts..." (λ () (void))))
                        (menu "&Data"
                              (menu-item "Update" (λ () (void)))
                              (menu-item "Add" (λ () (void)))))))

  (define mwr (render main-window))
  (displayln (format "~a" (renderer? mwr)))
  (render-popup-menu mwr m 10 10))

(module+ main
  (show))
```

got this error:
```
; instantiate: unused initialization arguments
;   unused arguments:
;    [id 2]
;   instantiated class name: renderer%
; Context (plain; to see better errortrace context, re-run with C-u prefix):
;   /Users/dhpark/.asdf/installs/racket/8.4/collects/racket/private/class-internal.rkt:4681:0 obj-error
;   /Users/dhpark/.asdf/installs/racket/8.4/collects/racket/private/class-internal.rkt:3321:17
;   /Users/dhpark/.asdf/installs/racket/8.4/collects/racket/private/class-internal.rkt:3608:0 continue-make-object
;   /Users/dhpark/Library/Racket/8.4/pkgs/gui-easy-lib/gui/easy/private/renderer.rkt:28:2
;   /Users/dhpark/.asdf/installs/racket/8.4/collects/racket/private/class-internal.rkt:3608:0 continue-make-object
;   /Users/dhpark/.asdf/installs/racket/8.4/collects/racket/private/class-internal.rkt:3582:0 do-make-object/real-class
;   /Users/dhpark/Library/Racket/8.4/pkgs/gui-easy-lib/gui/easy/private/renderer.rkt:79:0 render-popup-menu
;   /Users/dhpark/.asdf/installs/racket/8.4/collects/racket/contract/private/arrow-val-first.rkt:486:18
;   /Users/dhpark/tmp/popup-test.rkt:8:0 show
```

removing `[id id]` solved the problem.