### PR TITLE
correct defmixin domain

### DIFF
--- a/gui-easy/gui/easy/scribblings/reference.scrbl
+++ b/gui-easy/gui/easy/scribblings/reference.scrbl
@@ -633,7 +633,7 @@
 @; Require the private module to avoid requiring racket/gui/base.
 @(define ctxt-ev (make-base-eval '(require racket/class racket/gui/easy/private/view/view)))
 
-@defmixin[context-mixin (class?) (context<%>)]{
+@defmixin[context-mixin (object%) (context<%>)]{
   Specializes a class to implement the @racket[context<%>] interface.
   Compares keys using @racket[eq?].
 


### PR DESCRIPTION
According to the documentation, the domain-ids should be classes or interfaces with documentation, not predicates. Since this mixin accepts any object, `object%` is the appropriate domain.

This should hopefully fix the following warning, too:
```
2023-01-25T16:05:33.3192826Z raco setup: WARNING: undefined tag in <pkgs>/gui-easy/gui/easy/scribblings/gui-easy.scrbl:
2023-01-25T16:05:33.3193800Z raco setup:  (cls/intf ((lib "racket/private/class-internal.rkt") class?))
```