### PR TITLE
fix docs on list-view's default style

### DIFF
--- a/gui-easy/gui/easy/scribblings/reference.scrbl
+++ b/gui-easy/gui/easy/scribblings/reference.scrbl
@@ -264,7 +264,7 @@
                              (listof (or/c 'horizontal 'vertical 'border 'deleted
                                            'hscroll 'auto-hscroll 'hide-hscroll
                                            'vscroll 'auto-vscroll 'hide-vscroll))
-                             null]
+                             '(vertical auto-vscroll)]
                     [#:spacing spacing (maybe-obs/c spacing/c) 0]
                     [#:margin margin (maybe-obs/c margin/c) '(0 0)]
                     [#:min-size min-size (maybe-obs/c size/c) '(#f #f)]


### PR DESCRIPTION
The default `null` made me thing `'(vscroll)` was enough to force the scroll-bar to stick around; imagine my surprise when the list was suddenly horizontal, instead.

The code uses `'(vertical auto-vscroll)`, so put that in the docs, too.