### PR TITLE
fix latex docs

### DIFF
--- a/gui-easy/gui/easy/scribblings/gui-easy.scrbl
+++ b/gui-easy/gui/easy/scribblings/gui-easy.scrbl
@@ -2,6 +2,8 @@
 
 @(require scribble/core
           scribble/html-properties
+          scribble/latex-properties
+          racket/runtime-path
           (for-label racket/base
                      racket/gui/easy
                      racket/gui/easy/operator))
@@ -13,10 +15,12 @@ This library provides a declarative API on top of
 @racketmodname[racket/gui].  This library is still a work in progress,
 so expect some breaking changes.
 
+@(define-runtime-path youtubestub.tex "youtubestub.tex")
 @(define embed-style
   (make-style
-   "youtube-embed"
+   "youtubeembed"
    (list
+    (make-tex-addition youtubestub.tex)
     (make-alt-tag "iframe")
     (make-attributes '((width           . "700")
                        (height          . "394")

--- a/gui-easy/gui/easy/scribblings/youtubestub.tex
+++ b/gui-easy/gui/easy/scribblings/youtubestub.tex
@@ -1,0 +1,1 @@
+\def\youtubeembed{\relax}


### PR DESCRIPTION
This adjusts the documentation to build in latex mode.

I'm not completely sure if the renaming I did to change `youtube-embed` to `youtubeembed` is kosher. The html still looks okay to me, tho. I did that change because latex macro names cannot have hyphens in them, apparently.