### PR TITLE
view: fix scaling of image

### DIFF
--- a/gui-easy-lib/gui/easy/private/view/image.rkt
+++ b/gui-easy-lib/gui/easy/private/view/image.rkt
@@ -82,16 +82,20 @@
            (values
             (send bmp get-width)
             (send bmp get-height)))
+         (define r (/ sh sw))
+         (define-values (pw ph)
+           (values
+            (if w w (/ h r))      ; in case of either w or h is #f
+            (if h h (* w r))))
          (define-values (w* h*)
            (case mode
              [(fill)
               (values w h)]
 
              [(fit)
-              (define r (/ sh sw))
-              (if (>= (* w r) h)
-                  (values (exact-ceiling (/ h r)) h)
-                  (values w (exact-ceiling (* w r))))]))
+              (if (>= (* pw r) ph)
+                  (values (exact-ceiling (/ ph r)) ph)
+                  (values pw (exact-ceiling (* pw r))))]))
          (define bmp-dc
            (new gui:bitmap-dc%
                 [bitmap (gui:make-bitmap w* h* #:backing-scale backing-scale)]))

--- a/gui-easy-lib/gui/easy/private/view/image.rkt
+++ b/gui-easy-lib/gui/easy/private/view/image.rkt
@@ -85,12 +85,12 @@
          (define r (/ sh sw))
          (define-values (pw ph)
            (values
-            (if w w (/ h r))      ; in case of either w or h is #f
+            (if w w (exact-ceiling (/ h r)))      ; in case of either w or h is #f
             (if h h (* w r))))
          (define-values (w* h*)
            (case mode
              [(fill)
-              (values w h)]
+              (values pw ph)]
 
              [(fit)
               (if (>= (* pw r) ph)


### PR DESCRIPTION
The ```image```'s ```#:size``` property doesn't work well with something like ```'(#f 300)```, it tries to treat both of them as integers when they are not both ```#f``` and that's the point.
The problem happens in its internal ```scale``` function and I made it to scale either ```w``` or ```h``` following it original scale when one of them is ```#f``` so it can properly fit the frame.
BTW I don't know if it is fine for ```'fill``` mode...maybe it deserves further consideration.

The problem can be tested with this piece of code.

```racket
#lang racket/base

;;; (require "gui-easy-lib/gui/easy.rkt")
(require racket/gui/easy)

(define @height (obs 300))

(render
 (window
  (vpanel
   (slider
    300
    (λ (v) (obs-set! @height v))
    #:min-value 100
    #:max-value 800)
   (image
    #:size (obs-map @height (λ (h) (list #f h)))
    "path/to/photo.jpg")))) ;;; Whatever, a non-square-like photo
```