### PR TITLE
Add checkable-menu-item

### DIFF
--- a/examples/menu.rkt
+++ b/examples/menu.rkt
@@ -3,6 +3,7 @@
 (define/obs @menu-bar-enabled? #t)
 (define/obs @file-menu-enabled? #t)
 (define/obs @can-save? #t)
+(define/obs @checked? #f)
 
 (render
  (window
@@ -22,7 +23,12 @@
                     '(cmd #\s)
                     '(ctl #\s)))
     (menu-item-separator)
-    (menu-item "&Print...")))
+    (checkable-menu-item
+     (@checked? . ~> . (λ (checked?) (if checked?
+                                         "This is checked"
+                                         "This is not checked")))
+     (λ:= @checked?)
+     #:checked? @checked?)))
   (vpanel
    (button
     "Toggle Menu Bar"

--- a/gui-easy-lib/gui/easy/view.rkt
+++ b/gui-easy-lib/gui/easy/view.rkt
@@ -53,7 +53,7 @@
                   view/c)]
   [checkable-menu-item (->* ((maybe-obs/c maybe-label/c))
                             ((-> boolean? any)
-                             #:checked? (maybe-obs/c boolean?)
+                             #:checked? (maybe-obs/c any/c)
                              #:enabled? (maybe-obs/c any/c)
                              #:help (maybe-obs/c (or/c #f string?))
                              #:shortcut (maybe-obs/c (or/c #f (*list/c

--- a/gui-easy-lib/gui/easy/view.rkt
+++ b/gui-easy-lib/gui/easy/view.rkt
@@ -51,6 +51,16 @@
                                                      (or/c 'alt 'cmd 'meta 'ctl 'shift 'option)
                                                      (or/c char? symbol?)))))
                   view/c)]
+  [checkable-menu-item (->* ((maybe-obs/c maybe-label/c))
+                            ((-> boolean? any)
+                             #:checked? (maybe-obs/c boolean?)
+                             #:enabled? (maybe-obs/c any/c)
+                             #:help (maybe-obs/c (or/c #f string?))
+                             #:shortcut (maybe-obs/c (or/c #f (*list/c
+                                                               (or/c 'alt 'cmd 'meta 'ctl 'shift 'option)
+                                                               (or/c 'alt 'cmd 'meta 'ctl 'shift 'option)
+                                                               (or/c char? symbol?)))))
+                            view/c)]
   [menu-item-separator (-> view/c)]
 
   ;; Containers

--- a/gui-easy/gui/easy/scribblings/reference.scrbl
+++ b/gui-easy/gui/easy/scribblings/reference.scrbl
@@ -172,6 +172,18 @@
   ]
 }
 
+@defproc[(checkable-menu-item [label (maybe-obs/c maybe-label/c)]
+                              [action (-> boolean? any) void]
+                              [#:checked? checked? (maybe-obs/c boolean?) #f]
+                              [#:enabled? enabled? (maybe-obs/c any/c) #t]
+                              [#:help help-text (maybe-obs/c (or/c #f string?)) #f]
+                              [#:shortcut shortcut (maybe-obs/c (or/c #f (*list/c
+                                                                          (or/c 'alt 'cmd 'meta 'ctl 'shift 'option)
+                                                                          (or/c 'alt 'cmd 'meta 'ctl 'shift 'option)
+                                                                          (or/c char? symbol?)))) #f]) (is-a?/c view<%>)]{
+
+  Returns a representation of a menu item with a checkbox. The @racket[action] callback is called with the current checked state when the menu item is clicked. Use @racket[#:checked?] to set or update the checkbox programmatically.}
+
 @defproc[(menu-item-separator) (is-a?/c view<%>)]{
   Returns a representation of a menu item separator.
 }

--- a/gui-easy/gui/easy/scribblings/reference.scrbl
+++ b/gui-easy/gui/easy/scribblings/reference.scrbl
@@ -174,7 +174,7 @@
 
 @defproc[(checkable-menu-item [label (maybe-obs/c maybe-label/c)]
                               [action (-> boolean? any) void]
-                              [#:checked? checked? (maybe-obs/c boolean?) #f]
+                              [#:checked? checked? (maybe-obs/c any/c) #f]
                               [#:enabled? enabled? (maybe-obs/c any/c) #t]
                               [#:help help-text (maybe-obs/c (or/c #f string?)) #f]
                               [#:shortcut shortcut (maybe-obs/c (or/c #f (*list/c


### PR DESCRIPTION
Fixes #51.

That was easier than I expected. (Thanks for the nice code!) I mostly copied `menu-item` and added the relevant stuff.

I originally had the `#:checked?` contract as `maybe-obs/c boolean?` but I changed it to `maybe-obs/c any/c` so it was more like the `#:enabled?` parameter and to match the `gui:checkable-menu-item%` documentation.