### PR TITLE
add `intersonate-obs` and `chaperone-obs`

### DIFF
--- a/gui-easy-lib/gui/easy/contract.rkt
+++ b/gui-easy-lib/gui/easy/contract.rkt
@@ -47,17 +47,10 @@
             [(obs? o)
              (check-init-value (obs-peek o) neg-party)
              (impersonate-obs o
-                              (λ (_ name) name)
-                              (λ (_ update-proc)
-                                (chaperone-procedure
-                                 update-proc
-                                 (λ (proc)
-                                   (values
-                                    (λ (v)
-                                      (check-updated-value v neg-party)
-                                      v)
-                                    proc)))))]
-
+                              #:set
+                              (lambda (_ v)
+                                (check-updated-value v neg-party)
+                                v))]
             [else
              (raise-blame-error
               #:missing-party neg-party

--- a/gui-easy-lib/gui/easy/observable.rkt
+++ b/gui-easy-lib/gui/easy/observable.rkt
@@ -25,4 +25,12 @@
                      obs?)]
   [obs-throttle (->* (obs?)
                      (#:duration exact-nonnegative-integer?)
-                     obs?)]))
+                     obs?)]
+  [chaperone-obs (->* (obs?)
+                      (#:ref (or/c #f (-> obs? any/c any/c))
+                       #:set (or/c #f (-> obs? any/c any/c)))
+                      obs?)]
+  [impersonate-obs (->* (obs?)
+                        (#:ref (or/c #f (-> obs? any/c any/c))
+                         #:set (or/c #f (-> obs? any/c any/c)))
+                        obs?)]))

--- a/gui-easy-lib/info.rkt
+++ b/gui-easy-lib/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 
 (define license 'BSD-3-Clause)
-(define version "0.18.1")
+(define version "0.19")
 (define collection "racket")
 (define deps
   '("base"

--- a/gui-easy/gui/easy/scribblings/reference.scrbl
+++ b/gui-easy/gui/easy/scribblings/reference.scrbl
@@ -969,6 +969,26 @@ that equality (via @racket[equal?]) is preserved for
   values change at most once every @racket[duration-ms] milliseconds.
 }
 
+@deftogether[(
+@defproc[(impersonate-obs [o obs?]
+                          [#:ref ref-proc (or/c #f (-> obs? any/c any/c))]
+                          [#:set set-proc (or/c #f (-> obs? any/c any/c))])
+         obs?]
+@defproc[(chaperone-obs [o obs?]
+                        [#:ref ref-proc (or/c #f (-> obs? any/c any/c))]
+                        [#:set set-proc (or/c #f (-> obs? any/c any/c))])
+         obs?]
+)]{
+
+  Returns an impersonator or chaperone of an observable where wrappers
+  optionally redirect access and update of the observable's value,
+  analogous to @racket[impersonate-box] and @racket[chaperone-box]. In
+  the case of @racket[chaperone-obs], the value produced by a wrapper
+  procedure must be a chaperone of the wrapper's second argument.
+
+  @history[#:added "0.19"]
+}
+
 
 @section{View Helpers}
 


### PR DESCRIPTION
The `impersonate-obs` function existed internally to implement `obs/c`. This commit adjusts the arguments to that function, makes it exported, and adds `chaperone-obs`. That way, other contract-like layers can be implemented, including Rhombus annotations.

The change bumps the version number, and I think 0.19 is the right next version, but I'm not certain.