### PR TITLE
Exposes obs-name

### DIFF
--- a/gui-easy-lib/gui/easy/observable.rkt
+++ b/gui-easy-lib/gui/easy/observable.rkt
@@ -10,6 +10,7 @@
              #:derived? boolean?]
             obs?)]
   [obs? (-> any/c boolean?)]
+  [obs-name (-> obs? symbol?)]
   [obs-rename (-> obs? symbol? obs?)]
   [obs-observe! (-> obs? (-> any/c any) void?)]
   [obs-unobserve! (-> obs? (-> any/c any) void?)]


### PR DESCRIPTION
A tiny modification to expose `obs-name` that can be useful to code making use of gui-easy