### PR TITLE
Modified the input control to also respond to losing / gaining the focus

### DIFF
--- a/gui-easy-lib/gui/easy/private/view/input.rkt
+++ b/gui-easy-lib/gui/easy/private/view/input.rkt
@@ -51,7 +51,7 @@
       (when background-color
         (send the-field set-field-background background-color))
       (begin0 the-field
-              (send the-field set-context 'last-val content)))
+        (send the-field set-context 'last-val content)))
 
     (define (call-preserving-position ed thunk)
       (define old-text (send ed get-text))
@@ -69,56 +69,56 @@
         (and (= start 0)
              (= end (string-length old-text))))
       (begin0 (thunk)
-              ;; When the contents of the editor are empty, avoid changing
-              ;; the position since doing so would place the cursor before
-              ;; any newly-inserted text.
-              (unless (string=? "" old-text)
-                (if full-selection?
-                    (send ed set-position 0 (string-length (send ed get-text)))
-                    (send ed set-position start end)))))
+        ;; When the contents of the editor are empty, avoid changing
+        ;; the position since doing so would place the cursor before
+        ;; any newly-inserted text.
+        (unless (string=? "" old-text)
+          (if full-selection?
+              (send ed set-position 0 (string-length (send ed get-text)))
+              (send ed set-position start end)))))
 
     (define/public (update v what val)
       (case/dep what
-                [@label
-                 (send v set-label val)]
-                [@content
-                 (define last-val (send v get-context 'last-val))
-                 (define text
-                   (value->text val))
-                 (cond
-                   [(not (value=? val last-val))
-                    (send v set-context 'last-val val)
-                    (call-preserving-position
-                     (send v get-editor)
-                     (lambda ()
-                       (send v set-value text)
-                       (send v refresh)))]
+        [@label
+         (send v set-label val)]
+        [@content
+         (define last-val (send v get-context 'last-val))
+         (define text
+           (value->text val))
+         (cond
+           [(not (value=? val last-val))
+            (send v set-context 'last-val val)
+            (call-preserving-position
+             (send v get-editor)
+             (lambda ()
+               (send v set-value text)
+               (send v refresh)))]
 
-                   [(string=? text "")
-                    (send v set-value "")
-                    (send v refresh)]
+           [(string=? text "")
+            (send v set-value "")
+            (send v refresh)]
 
-                   [else
-                    (void)])]
-                [@enabled?
-                 (send v enable val)]
-                [@background-color
-                 (send v set-field-background val)]
-                [@margin
-                 (match-define (list h-m v-m) val)
-                 (send* v
-                   (horiz-margin h-m)
-                   (vert-margin v-m))]
-                [@min-size
-                 (match-define (list w h) val)
-                 (send* v
-                   (min-width (or w 0))
-                   (min-height (or h 0)))]
-                [@stretch
-                 (match-define (list w-s? h-s?) val)
-                 (send* v
-                   (stretchable-width w-s?)
-                   (stretchable-height h-s?))]))
+           [else
+            (void)])]
+        [@enabled?
+         (send v enable val)]
+        [@background-color
+         (send v set-field-background val)]
+        [@margin
+         (match-define (list h-m v-m) val)
+         (send* v
+           (horiz-margin h-m)
+           (vert-margin v-m))]
+        [@min-size
+         (match-define (list w h) val)
+         (send* v
+           (min-width (or w 0))
+           (min-height (or h 0)))]
+        [@stretch
+         (match-define (list w-s? h-s?) val)
+         (send* v
+           (stretchable-width w-s?)
+           (stretchable-height h-s?))]))
     
     (define/public (destroy v)
       (send v clear-context))))
@@ -145,18 +145,17 @@
                                       [(#t) 'has-focus]
                                       [(#f) 'lost-focus])
                                     (send this get-value)))))  
-    (new (input% (mix modified-text-field%))
-         [@label @label]
-         [@content @content]
-         [@enabled? @enabled?]
-         [@background-color @background-color]
-         [@margin @margin]
-         [@min-size @min-size]
-         [@stretch @stretch]
-         [action action]
-         [style style]
-         [font font]
-         [keymap keymap]
-         [value=? value=?]
-         [value->text value->text]))
-  
+  (new (input% (mix modified-text-field%))
+       [@label @label]
+       [@content @content]
+       [@enabled? @enabled?]
+       [@background-color @background-color]
+       [@margin @margin]
+       [@min-size @min-size]
+       [@stretch @stretch]
+       [action action]
+       [style style]
+       [font font]
+       [keymap keymap]
+       [value=? value=?]
+       [value->text value->text]))

--- a/gui-easy-lib/gui/easy/view.rkt
+++ b/gui-easy-lib/gui/easy/view.rkt
@@ -159,7 +159,7 @@
                #:mode (maybe-obs/c (or/c 'fit 'fill))]
               view/c)]
   [input (->* [(maybe-obs/c any/c)]
-              [(-> (or/c 'input 'return) string? any)
+              [(-> (or/c 'input 'return 'has-focus 'lost-focus) string? any)
                #:label (maybe-obs/c maybe-label/c)
                #:enabled? (maybe-obs/c boolean?)
                #:background-color (maybe-obs/c (or/c #f (is-a?/c gui:color%)))

--- a/gui-easy/gui/easy/scribblings/reference.scrbl
+++ b/gui-easy/gui/easy/scribblings/reference.scrbl
@@ -542,7 +542,7 @@ packages in the Racket ecosystem, into their projects.
 }
 
 @defproc[(input [value (maybe-obs/c any/c)]
-                [action (-> (or/c 'input 'return) string? any) void]
+                [action (-> (or/c 'input 'return 'has-focus 'lost-focus) string? any) void]
                 [#:label label (maybe-obs/c maybe-label/c) #f]
                 [#:enabled? enabled? (maybe-obs/c boolean?) #t]
                 [#:background-color background-color (maybe-obs/c (or/c #f (is-a?/c gui:color%))) #f]
@@ -559,7 +559,7 @@ packages in the Racket ecosystem, into their projects.
                 [#:value->text value->text (-> any/c string?) values]) (is-a?/c view<%>)]{
   Returns a representation of a text field that calls @racket[action]
   on change.  The first argument to the @racket[action] is the type of
-  event that caused the input to change and the second is the contents
+  event that the control is responding to and the second is the contents
   of the text field.
 
   The @racket[#:value=?] argument controls when changes to the input
@@ -574,6 +574,11 @@ packages in the Racket ecosystem, into their projects.
   The @racket[#:value->text] argument controls how the input values
   are rendered to strings.  If not provided, @racket[value] must be
   either a @racket[string?] or an observable of strings.
+
+  @history[
+    #:changed "0.21" @elem{@racket[input] also responds to the @racket['has-focus] and
+   @racket['lost-focus] events.}
+  ]
 }
 
 @defproc[(progress [value (maybe-obs/c gui:position-integer?)]


### PR DESCRIPTION
This PR proposes an intermediate solution to the way observable based views update their content once their observable has been updated.

Currently, observable based views completely recreate their content once their observable gets updated to reflect the new data values. This creates the interesting behaviour, where, when a view's controls update the view's observable, they get re-created and this means that an input control would lose focus. For example (try to edit the text in either of these boxes):

``` racket
#lang racket
(require racket/gui/easy
         racket/gui/easy/operator)

(define actual-value '("Alpha" "Beta"))
(define @value-a (obs (first actual-value)))
(define @value-b (obs (second actual-value)))
(define @top-obs (obs-combine (lambda (u v) (cons u v)) @value-a @value-b))

(define cursed-view
  (observable-view @top-obs
                   (lambda (d)
                     (vpanel
                     (input @value-a
                            (lambda (u v) (obs-set! @value-a v))                              
                            #:label "Value - A")
                     (input @value-b
                            (lambda (u v) (obs-set! @value-b v))
                            #:label "Value - B")
                   #:min-size '(150 50)))))

(render
 (dialog cursed-view))
```

This PR adds two more events in the `input` control's `action`, `has-focus` and `lost-focus`. This does not change the updating behaviour of a given observable based view but makes the "re-creation" invisible because most of the times, the user has finished editing text in a given text box.

Compare the previous behaviour of the "Value - A" `input` to:

``` racket
#lang racket
(require racket/gui/easy
         racket/gui/easy/operator)

(define actual-value '("Alpha" "Beta"))
(define @value-a (obs (first actual-value)))
(define @value-b (obs (second actual-value)))
(define @top-obs (obs-combine (lambda (u v) (cons u v)) @value-a @value-b))

(define cursed-view
  (observable-view @top-obs
                   (lambda (d)
                     (vpanel
                     (input @value-a
                            (lambda (u v)
                              (case u
                                ['lost-focus (obs-set! @value-a v)]))                              
                            #:label "Value - A")
                     (input @value-b
                            (lambda (u v) (obs-set! @value-b v))
                            #:label "Value - B")
                   #:min-size '(150 50)))))

(render
 (dialog cursed-view))
```

