### PR TITLE
observable: refine GCability of derived observables

### DIFF
--- a/examples/tabs+checkbox.rkt
+++ b/examples/tabs+checkbox.rkt
@@ -1,0 +1,24 @@
+#lang racket/gui/easy
+
+(define/obs @tab "A")
+(define/obs @checked? #f)
+
+(define cb
+  (checkbox
+   (λ:= @checked?)
+   #:label "Check Me"
+   #:checked? @checked?))
+
+(render
+ (window
+  (tabs
+   '("A" "B")
+   #:selection @tab
+   (lambda (_event _tabs selection)
+     (@tab . := . selection))
+   (observable-view
+    @tab
+    (lambda (tab)
+      (vpanel
+       (text tab)
+       cb))))))

--- a/gui-easy-lib/info.rkt
+++ b/gui-easy-lib/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 
 (define license 'BSD-3-Clause)
-(define version "0.27.1")
+(define version "0.28")
 (define collection "racket")
 (define deps
   '("base"


### PR DESCRIPTION
Based on an idea by @mflatt in racket/rhombus#754. This changes derived observables so that they are held strongly while they have active subscriptions and weakly otherwise.