### PR TITLE
depend on the new "version-case-lib", instead of "version-case"

### DIFF
--- a/gui-easy-lib/info.rkt
+++ b/gui-easy-lib/info.rkt
@@ -9,6 +9,6 @@
     "draw-lib"
     "gui-lib"
     "pict-lib"
-    "version-case"))
+    "version-case-lib"))
 (define build-deps
   '("rackunit-lib"))


### PR DESCRIPTION
This change avoids a transitive dependency on documentation.